### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -13,7 +13,7 @@ class Lexer
     /**
      * @param SubLexerInterface $subLexer
      */
-    public function __construct(SubLexerInterface $subLexer = null)
+    public function __construct(?SubLexerInterface $subLexer = null)
     {
         $this->subLexer = $subLexer ?: static::createDefaultSubLexer();
     }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -15,7 +15,7 @@ class Parser
     /**
      * @param NodeParserInterface $nodeParser
      */
-    public function __construct(NodeParserInterface $nodeParser = null)
+    public function __construct(?NodeParserInterface $nodeParser = null)
     {
         $this->nodeParser = $nodeParser ?: static::createDefaultNodeParser();
     }


### PR DESCRIPTION
When using this library in a PHP 8.4 codebase, we get deprecation warnings due to implicitly nullable parameters.
We fixed these warnings by explicitly marking affected parameters as nullable.